### PR TITLE
Wrap ws.send() in try/catch to catch NS_ERROR_NOT_CONNECTED errors

### DIFF
--- a/lib/ws.js
+++ b/lib/ws.js
@@ -39,7 +39,11 @@ function wrap(ws) {
             ws.close();
         },
         write: function(data) {
-            ws.send(data_send(data), {binary:true});
+            try {
+                ws.send(data_send(data), {binary:true});
+            } catch (e) {
+                ws.onerror(e);
+            }
         },
         on: function(event, handler) {
             if (event === 'data') {


### PR DESCRIPTION
If you attempt to connect to an address:port that doesn't have a listener in FireFox, websockets will raise on uncaught error "NS_ERROR_NOT_CONNECTED".

By wrapping the ws.send() in a try/catch block and calling ws.onerror(), the connection's 'disconnected' error is called. 

However, when the connection was made using reconnect: true, the disconnected handler is called for each retry. I'm not sure if this is desired.
 