### PR TITLE
Patch allowing Buffer types to be used to encode AMQP long and ulong types

### DIFF
--- a/lib/types.js
+++ b/lib/types.js
@@ -270,6 +270,12 @@ function is_one_of(o, typelist) {
     }
     return false;
 }
+function buffer_zero(b, len, neg) {
+    for (var i = 0; i < len && i < b.length; i++) {
+        if (b[i] !== (neg ? 0xff : 0)) return false;
+    }
+    return true;
+}
 types.is_ulong = function(o) {
     return is_one_of(o, [types.Ulong, types.Ulong0, types.SmallUlong]);
 };
@@ -290,8 +296,13 @@ types.wrap_boolean = function(v) {
     return v ? new types.True() : new types.False();
 };
 types.wrap_ulong = function(l) {
-    if (l === 0) return new types.Ulong0();
-    else return l > 255 ? new types.Ulong(l) : new types.SmallUlong(l);
+    if (Buffer.isBuffer(l)) {
+        if (buffer_zero(l, 8, false)) return new types.Ulong0();
+        return buffer_zero(l, 7, false) ? new types.SmallUlong(l[7]) : new types.Ulong(l);
+    } else {
+        if (l === 0) return new types.Ulong0();
+        else return l > 255 ? new types.Ulong(l) : new types.SmallUlong(l);
+    }
 };
 types.wrap_uint = function(l) {
     if (l === 0) return new types.Uint0();
@@ -304,7 +315,15 @@ types.wrap_ubyte = function(l) {
     return new types.Ubyte(l);
 };
 types.wrap_long = function(l) {
-    return l > 127 || l < -128 ? new types.Long(l) : new types.SmallLong(l);
+    if (Buffer.isBuffer(l)) {
+        var negFlag = (l[0] & 0x80) !== 0;
+        if (buffer_zero(l, 7, negFlag) && (l[7] & 0x80) === (negFlag ? 0x80 : 0)) {
+            return new types.SmallLong(negFlag ? -((l[7] ^ 0xff) + 1) : l[7]);
+        }
+        return new types.Long(l);
+    } else {
+        return l > 127 || l < -128 ? new types.Long(l) : new types.SmallLong(l);
+    }
 };
 types.wrap_int = function(l) {
     return l > 127 || l < -128 ? new types.Int(l) : new types.SmallInt(l);


### PR DESCRIPTION
**Motivation:**
Current wrap methods for types long and ulong accept the Number type. However, owing to the fact that Number types use a 64-bit floating point representation internally, it is not possible to represent many long and unsigned long values of large numerical value without running into rounding errors.

For example:
Python:
```python
>>> int("0x7fffffffffffffff", 16)
9223372036854775807
```
which is the expected value. However, for Node.js:
```javascript
> parseInt("0x7fffffffffffffff", 16);
9223372036854776000
```
which contains a substantial rounding error. Applications which must send large `long` and `ulong` values need to find another way to represent these numbers.

One possible way to solve this is to use a `Buffer`, as these are already used internally within Rhea for encoding/decoding. The mechanism to send this would then take the form:
```javascript
var amqp_types = require('rhea/lib/types.js');
...
// Directly from number array

var ulongByteArray = [127, 255, 255, 255, 255, 255, 255, 255]; // 0x7fffffffffffffff
var msg = {body: amqp_types.wrap_ulong(new Buffer(ulongByteArray, 8)))};

```
or by any other method of encoding `long` and `ulong` values into a `Buffer`.

**NOTE**: I am new at javascript, please check carefully for any newbie/coding/style issues :)