### PR TITLE
REF: Rewrite yargs arg parser to minimist

### DIFF
--- a/examples/client.js
+++ b/examples/client.js
@@ -15,10 +15,14 @@
  */
 var container = require('rhea');
 
-var args = require('yargs').options({
-      'n': { alias: 'node', default: 'examples', describe: 'name of node (e.g. queue) to which messages are sent'},
-      'p': { alias: 'port', default: 5672, describe: 'port to connect to'}
-    }).help('help').argv;
+var args = require('minimist')(process.argv.slice(2),
+    {
+        string: ['node'],
+        number: ['port'],
+        alias: { n: 'node', p: 'port' },
+        default: { node: "examples", port: 5672 },
+    }
+);
 
 var requests = ["Twas brillig, and the slithy toves",
                 "Did gire and gymble in the wabe.",

--- a/examples/direct_recv.js
+++ b/examples/direct_recv.js
@@ -15,10 +15,13 @@
  */
 var container = require('rhea');
 
-var args = require('yargs').options({
-      'm': { alias: 'messages', default: 100, describe: 'number of messages to expect'},
-      'p': { alias: 'port', default: 8888, describe: 'port to connect to'}
-    }).help('help').argv;
+var args = require('minimist')(process.argv.slice(2),
+    {
+        number: ['messages', 'port'],
+        alias: { m: 'messages', p: 'port' },
+        default: { port: 8888, messages: 100 },
+    }
+);
 
 var received = 0;
 var expected = args.messages;

--- a/examples/direct_send.js
+++ b/examples/direct_send.js
@@ -15,10 +15,13 @@
  */
 var container = require('rhea');
 
-var args = require('yargs').options({
-      'm': { alias: 'messages', default: 100, describe: 'number of messages to send'},
-      'p': { alias: 'port', default: 8888, describe: 'port to connect to'}
-    }).help('help').argv;
+var args = require('minimist')(process.argv.slice(2),
+    {
+        number: ['messages', 'port'],
+        alias: { m: 'messages', p: 'port' },
+        default: { port: 8888, messages: 100 },
+    }
+);
 
 var server = container.listen({'port':args.port});
 

--- a/examples/direct_server.js
+++ b/examples/direct_server.js
@@ -15,9 +15,13 @@
  */
 var container = require('rhea');
 
-var args = require('yargs').options({
-      'p': { alias: 'port', default: 5672, describe: 'port to connect to'}
-    }).help('help').argv;
+var args = require('minimist')(process.argv.slice(2),
+    {
+        number: ['port'],
+        alias: { p: 'port' },
+        default: { port: 5672 },
+    }
+);
 
 //container.sasl_server_mechanisms.enable_anonymous();
 var server = container.listen({'port':args.port});

--- a/examples/drain.js
+++ b/examples/drain.js
@@ -15,10 +15,14 @@
  */
 var container = require('rhea');
 
-var args = require('yargs').options({
-      'n': { alias: 'node', default: 'examples', describe: 'name of node (e.g. queue) from which messages are received'},
-      'p': { alias: 'port', default: 5672, describe: 'port to connect to'}
-    }).help('help').argv;
+var args = require('minimist')(process.argv.slice(2),
+    {
+        string: ['node'],
+        number: ['port'],
+        alias: { n: 'node', p: 'port' },
+        default: { node: "examples", port: 5672 },
+    }
+);
 
 var batch = 10;
 var received = 0;

--- a/examples/durable_subscription/publisher.js
+++ b/examples/durable_subscription/publisher.js
@@ -13,11 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-var args = require('yargs').options({
-      't': { alias: 'topic', default: 'topic://PRICE.STOCK.NYSE.RHT', describe: 'name of topic to which messages are sent'},
-      'p': { alias: 'port', default: 5672, describe: 'port to connect to'}
-    }).usage('Usage: $0 [options] <messages>').help('help').argv;
+var args = require('minimist')(process.argv.slice(2),
+    {
+        string: ['topic'],
+        number: ['port'],
+        alias: { t: 'topic', p: 'port' },
+        default: { topic: "topic://PRICE.STOCK.NYSE.RHT", port: 5672 },
+    }
+);
 
 var connection = require('rhea').connect({'port':args.port});
 var sender = connection.open_sender(args.topic);

--- a/examples/durable_subscription/subscriber.js
+++ b/examples/durable_subscription/subscriber.js
@@ -15,12 +15,14 @@
  * limitations under the License.
  */
 
-var args = require('yargs').options({
-      'client': { default: 'my-client', describe: 'name of identifier for client container'},
-      'subscription': { default: 'my-subscription', describe: 'name of identifier for subscription'},
-      't': { alias: 'topic', default: 'topic://PRICE.STOCK.NYSE.*', describe: 'name of topic to subscribe to'},
-      'p': { alias: 'port', default: 5672, describe: 'port to connect to'}
-    }).help('help').argv;
+var args = require('minimist')(process.argv.slice(2),
+    {
+        string: ['client', 'subscription', 'topic'],
+        number: ['port'],
+        alias: { t: 'topic', p: 'port' },
+        default: { port: 5672, topic: 'topic://PRICE.STOCK.NYSE.*', client: 'my-client', subscription: 'my-subscription' },
+    }
+);
 
 var connection = require('rhea').connect({port:args.port, container_id:args.client});
 connection.on('message', function (context) {

--- a/examples/queue_browser.js
+++ b/examples/queue_browser.js
@@ -15,11 +15,14 @@
  */
 var container = require('rhea');
 
-var args = require('yargs').options({
-      'm': { alias: 'messages', default: 100, describe: 'number of messages to expect'},
-      'n': { alias: 'node', default: 'examples', describe: 'name of queue to browse'},
-      'p': { alias: 'port', default: 5672, describe: 'port to connect to'}
-    }).help('help').argv;
+var args = require('minimist')(process.argv.slice(2),
+    {
+        string: ['node'],
+        number: ['messages', 'port'],
+        alias: { m: 'messages', n: 'node', p: 'port' },
+        default: { node: "examples", port: 5672, messages: 100 },
+    }
+);
 
 var received = 0;
 var expected = args.messages;

--- a/examples/reconnect/client.js
+++ b/examples/reconnect/client.js
@@ -15,17 +15,14 @@
  */
 var container = require('rhea');
 
-var args = require('yargs').options({
-      'request_interval': {describe: 'interval between requests', default:1000},
-      'fixed_delay': {describe: 'fixed reconnect delay'},
-      'initial_delay': {describe: 'initial reconnect delay'},
-      'max_delay': {describe: 'max reconnect delay'},
-      'reconnect_limit': {describe: 'maximum number of reconnect attempts'},
-      'disable_reconnect': {type:'boolean', describe: 'disable reconnect'},
-      'idle_time_out': {describe: 'maximum idle timeout; if nothing is received from peer for this interval, consider connection dead'},
-      'm': { alias: 'messages', default: 100, describe: 'number of messages to send'},
-      'p': { alias: 'ports', default: [8888], type: 'array', describe: 'port to connect to'}
-    }).help('help').argv;
+var args = require('minimist')(process.argv.slice(2),
+    {
+        number: ['ports', 'mesages', 'request_interval', 'fixed_delay', 'max_delay', 'reconnect_limit', 'idle_time_out'],
+        boolean: ['disable_reconnect'],
+        alias: { m: 'messages', p: 'ports' },
+        default: { ports: [8888], messages: 100, request_interval: 1000 },
+    }
+);
 
 var requests = args.messages;
 var current = 1;

--- a/examples/reconnect/echo.js
+++ b/examples/reconnect/echo.js
@@ -15,10 +15,13 @@
  */
 var container = require('rhea');
 
-var args = require('yargs').options({
-      'm': { alias: 'messages', default: 0, describe: 'number of messages to expect'},
-      'p': { alias: 'port', default: 8888, describe: 'port to connect to'}
-    }).help('help').argv;
+var args = require('minimist')(process.argv.slice(2),
+    {
+        number: ['port', 'messages'],
+        alias: { m: 'messages', p: 'port' },
+        default: { messages: 0, port: 8888 },
+    }
+);
 
 var received = 0;
 var expected = args.messages;

--- a/examples/sasl/sasl_anonymous_server.js
+++ b/examples/sasl/sasl_anonymous_server.js
@@ -14,9 +14,13 @@
  * limitations under the License.
  */
 var container = require('rhea');
-var args = require('yargs').options({
-      'p': { alias: 'port', default: 5672, describe: 'port to listen on'}
-    }).help('help').argv;
+var args = require('minimist')(process.argv.slice(2),
+    {
+        number: ['port'],
+        alias: { p: 'port' },
+        default: { port: 5672 },
+    }
+);
 
 container.sasl_server_mechanisms.enable_anonymous();
 var server = container.listen({'port':args.port});

--- a/examples/sasl/sasl_plain_server.js
+++ b/examples/sasl/sasl_plain_server.js
@@ -14,9 +14,13 @@
  * limitations under the License.
  */
 var container = require('rhea');
-var args = require('yargs').options({
-      'p': { alias: 'port', default: 5672, describe: 'port to listen on'}
-    }).help('help').argv;
+var args = require('minimist')(process.argv.slice(2),
+    {
+        number: ['port'],
+        alias: { p: 'port' },
+        default: { port: 5672 },
+    }
+);
 
 /**
  * To authenticate using PLAIN and a simple username and password

--- a/examples/sasl/simple_sasl_client.js
+++ b/examples/sasl/simple_sasl_client.js
@@ -14,11 +14,14 @@
  * limitations under the License.
  */
 var container = require('rhea');
-var args = require('yargs').options({
-      'username': { describe: 'username to connect with'},
-      'password': { describe: 'password to connect with (will use PLAIN)'},
-      'p': { alias: 'port', default: 5671, describe: 'port to connect to'}
-    }).help('help').argv;
+var args = require('minimist')(process.argv.slice(2),
+    {
+        string: ['username', 'password'],
+        number: ['port'],
+        alias: { p: 'port' },
+        default: { port: 5672 },
+    }
+);
 
 /**
  * Default SASL behaviour is as follows. If the username and password

--- a/examples/selector/recv.js
+++ b/examples/selector/recv.js
@@ -16,12 +16,14 @@
 var container = require('rhea');
 var filters = require('rhea/lib/filter.js');
 
-var args = require('yargs').options({
-      's': { alias: 'selector', default: "colour = 'red'", describe: 'the selector string to use'},
-      'm': { alias: 'messages', default: 100, describe: 'number of messages to expect'},
-      'n': { alias: 'node', default: 'examples', describe: 'name of node (e.g. queue or topic) from which messages are received'},
-      'p': { alias: 'port', default: 5672, describe: 'port to connect to'}
-    }).help('help').argv;
+var args = require('minimist')(process.argv.slice(2),
+    {
+        string: ['node', 'selector'],
+        number: ['messages', 'port'],
+        alias: { m: 'messages', n: 'node', p: 'port', s: 'selector' },
+        default: { node: "examples", port: 5672, messages: 100, selector: "colour = 'red'" },
+    }
+);
 
 var received = 0;
 var expected = args.messages;

--- a/examples/selector/send.js
+++ b/examples/selector/send.js
@@ -14,10 +14,14 @@
  * limitations under the License.
  */
 
-var args = require('yargs').options({
-      'n': { alias: 'node', default: 'examples', describe: 'name of node (e.g. queue or topic) to which messages are sent'},
-      'p': { alias: 'port', default: 5672, describe: 'port to connect to'}
-    }).usage('Usage: $0 [options] <messages>').help('help').argv;
+var args = require('minimist')(process.argv.slice(2),
+    {
+        string: ['node'],
+        number: ['port'],
+        alias: { n: 'node', p: 'port' },
+        default: { node: "examples", port: 5672 },
+    }
+);
 
 var connection = require('rhea').connect({'port':args.port});
 var sender = connection.open_sender(args.node);

--- a/examples/simple_recv.js
+++ b/examples/simple_recv.js
@@ -15,11 +15,14 @@
  */
 var container = require('rhea');
 
-var args = require('yargs').options({
-      'm': { alias: 'messages', default: 100, describe: 'number of messages to expect'},
-      'n': { alias: 'node', default: 'examples', describe: 'name of node (e.g. queue) from which messages are received'},
-      'p': { alias: 'port', default: 5672, describe: 'port to connect to'}
-    }).help('help').argv;
+var args = require('minimist')(process.argv.slice(2),
+    {
+        string: ['node'],
+        number: ['messages', 'port'],
+        alias: { m: 'messages', n: 'node', p: 'port' },
+        default: { node: "examples", port: 5672, messages: 100 },
+    }
+);
 
 var received = 0;
 var expected = args.messages;

--- a/examples/simple_send.js
+++ b/examples/simple_send.js
@@ -15,11 +15,14 @@
  */
 var container = require('rhea');
 
-var args = require('yargs').options({
-      'm': { alias: 'messages', default: 100, describe: 'number of messages to send'},
-      'n': { alias: 'node', default: 'examples', describe: 'name of node (e.g. queue) to which messages are sent'},
-      'p': { alias: 'port', default: 5672, describe: 'port to connect to'}
-    }).help('help').argv;
+var args = require('minimist')(process.argv.slice(2),
+    {
+        string: ['node'],
+        number: ['messages', 'port'],
+        alias: { m: 'messages', n: 'node', p: 'port' },
+        default: { node: "examples", port: 5672, messages: 100 },
+    }
+);
 
 var confirmed = 0, sent = 0;
 var total = args.messages;

--- a/examples/tls/tls_client.js
+++ b/examples/tls/tls_client.js
@@ -16,11 +16,14 @@
 var container = require('rhea');
 var fs = require('fs');
 var path = require('path');
-var args = require('yargs').options({
-    's': {alias: 'servername', default: undefined, describe: 'name to use for SNI'},
-    'h': {alias: 'host', default: 'localhost', describe: 'host to connect to'},
-    'p': { alias: 'port', default: 5671, describe: 'port to connect to'}
-}).help('help').argv;
+var args = require('minimist')(process.argv.slice(2),
+    {
+        string: ['servername', 'host'],
+        number: ['port'],
+        alias: { s: 'servername', h: 'host', p: 'port' },
+        default: { host: "localhost", port: 5671, servername: undefined },
+    }
+);
 
 
 container.on('connection_open', function (context) {

--- a/examples/tls/tls_server.js
+++ b/examples/tls/tls_server.js
@@ -16,9 +16,13 @@
 var container = require('rhea');
 var fs = require('fs');
 var path = require('path');
-var args = require('yargs').options({
-      'p': { alias: 'port', default: 5671, describe: 'port to listen on'}
-    }).help('help').argv;
+var args = require('minimist')(process.argv.slice(2),
+    {
+        number: ['port'],
+        alias: { p: 'port' },
+        default: { port: 5671 },
+    }
+);
 
 container.on('connection_open', function (context) {
     var cert = context.connection.get_peer_certificate();

--- a/examples/websockets/client.js
+++ b/examples/websockets/client.js
@@ -17,10 +17,14 @@ var client = require('rhea');
 var WebSocket = require('ws');
 var ws = client.websocket_connect(WebSocket);
 
-var args = require('yargs').options({
-      'm': { alias: 'messages', default: 100, describe: 'number of messages to send'},
-      'u': { alias: 'url', default: 'ws://localhost:5673', describe: 'url to connect to'}
-    }).help('help').argv;
+var args = require('minimist')(process.argv.slice(2),
+    {
+        string: ['url'],
+        number: ['messages'],
+        alias: { m: 'messages', u: 'url' },
+        default: { url: "ws://localhost:5673", messages: 100 },
+    }
+);
 
 var requests = args.messages;
 var current = 1;

--- a/examples/websockets/echo.js
+++ b/examples/websockets/echo.js
@@ -15,10 +15,13 @@
  */
 var container = require('rhea');
 
-var args = require('yargs').options({
-      'm': { alias: 'messages', default: 0, describe: 'number of messages to expect'},
-      'p': { alias: 'port', default: 8888, describe: 'port to listen on'}
-    }).help('help').argv;
+var args = require('minimist')(process.argv.slice(2),
+    {
+        number: ['messages', 'port'],
+        alias: { m: 'messages', p: 'port' },
+        default: { messages: 0, port: 8888 },
+    }
+);
 
 var received = 0;
 var expected = args.messages;


### PR DESCRIPTION
Due to yargs dependencies require nodejs >= 4, I rewrote yargs in examples to minimist args parser for compatibility with nodejs 0.10.  