### PR TITLE
FIX: echo.js in websocket examples

### DIFF
--- a/examples/websockets/echo.js
+++ b/examples/websockets/echo.js
@@ -28,7 +28,7 @@ var expected = args.messages;
 var listeners = {};
 
 var WebSocketServer = require('ws').Server;
-var server = WebSocketServer({'port':args.port});
+var server = new WebSocketServer({'port':args.port});
 server.on('connection', function (ws) {
     console.log('Accepted incoming websocket connection');
     container.websocket_accept(ws);


### PR DESCRIPTION
~~
Due to new ws version, constructor of WebSocketServer must be called
with new.
~~