### PR TITLE
fix(packages) fix browserify command

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
         "lint": "eslint lib/*.js",
         "test": "mocha",
         "coverage": "istanbul cover _mocha",
-        "browserify": "browserify -r rhea -o rhea.js",
+        "browserify": "browserify -r .:rhea -o rhea.js",
         "run-examples": "mocha examples/test_examples.js"
     },
     "keywords": ["amqp","messaging"],


### PR DESCRIPTION
browserify command in package.json didn't work, when rhea was not installed in node_modules. This updated command does browserify transformation with local rhea files.